### PR TITLE
Table sorting/filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ After cloning the repo, install dependencies with `npm install`. Now you can bui
 
  - `npm run clean` : Clean the `/dist/` folder where the React app lives
  - `npm run build:core` : Build a production version
- - `npm start` : Build a development version, watch files for changes
+ - `npm run start` : Build a development version, watch files for changes
  - `npm run prebuild` : Check for outdated dependencies and update those found
 
 There are also some helper scripts:

--- a/classes/ActionScheduler_Admin.php
+++ b/classes/ActionScheduler_Admin.php
@@ -60,7 +60,7 @@ class ActionScheduler_Admin {
 		wp_register_script(
 			'scheduled-actions-admin',
 			plugins_url( '/dist/index.js', __DIR__ ),
-			[ 'wp-hooks', 'wp-element', 'wp-i18n', 'wc-components' ],
+			[ 'wp-hooks', 'wp-element', 'wp-i18n', 'wc-components', 'wc-navigation' ],
 			filemtime( dirname( __DIR__ ) . '/dist/index.js' ),
 			true
 		);

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -111,8 +111,9 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 			'offset'   => $request[ 'offset' ],
 			'per_page' => $request[ 'page' ],
 			'group'    => $request[ 'group' ],
-			'status'   => ActionScheduler_Store::STATUS_PENDING,
+			'status'   => $request[ 'status' ],
 			'orderby'  => strtolower( $request[ 'orderby' ] ),
+			'order'  => strtolower( $request[ 'order' ] ),
 		];
 
 		$args[ 'orderby' ] = in_array( $args[ 'orderby' ], [ 'hook', 'group' ], true ) ? $args[ 'orderby' ] : '';
@@ -148,6 +149,10 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 			$parameters       = [];
 
 			foreach ( $action->get_args() as $key => $value ) {
+				if ( is_array( $value ) || is_object( $value ) ) {
+					$value = wp_json_encode( $value );
+				}
+
 				$parameters[] = sprintf( '%s => %s', $key, $value );
 			}
 

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -265,7 +265,7 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 		}
 
 		$schedule_display['timestamp'] = $schedule->next()->getTimestamp();
-		$schedule_display['date']      = $schedule->next()->format( 'Y-m-d H:i:s O' );
+		$schedule_display['date']      = $schedule->next()->format( 'Y-m-d H:i:sP' );
 
 		if ( gmdate( 'U' ) > $schedule_display['timestamp'] ) {
 			$schedule_display['delta'] = sprintf( __( '(%s ago)', 'action-scheduler-admin' ), self::human_interval( gmdate( 'U' ) - $schedule_display['timestamp'] ) );

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -126,9 +126,9 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 	 * @return array Of WP_Error or WP_REST_Response.
 	 */
 	public function get_actions( $request ) {
-		$args     = $this->prepare_actions_query( $request );
-		$actions  = as_get_scheduled_actions( $args );
-		$data     = [];
+		$args    = $this->prepare_actions_query( $request );
+		$actions = as_get_scheduled_actions( $args );
+		$data    = [];
 
 		try {
 			$timezone = new DateTimeZone( get_option( 'timezone_string' ) );

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -127,9 +127,11 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 	 * @return array Of WP_Error or WP_REST_Response.
 	 */
 	public function get_actions( $request ) {
-		$args    = $this->prepare_actions_query( $request );
-		$actions = as_get_scheduled_actions( $args );
-		$data    = [];
+		$args          = $this->prepare_actions_query( $request );
+		$actions       = as_get_scheduled_actions( $args );
+		$data          = [];
+		$store         = ActionScheduler::store();
+		$status_labels = $store->get_status_labels();
 
 		try {
 			$timezone = new DateTimeZone( get_option( 'timezone_string' ) );
@@ -156,10 +158,17 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 				$parameters[] = sprintf( '%s => %s', $key, $value );
 			}
 
+			try {
+				$status = $store->get_status( $action_id );
+			} catch ( Exception $e ) {
+				$status = '';
+			}
+
 			$action_data = [
 				'id'             => $action_id,
 				'hook'           => $action->get_hook(),
 				'group'          => $action->get_group(),
+				'status'         => isset( $status_labels[ $status ] ) ? $status_labels[ $status ] : $status,
 				'timestamp'      => $schedule_display['timestamp'],
 				'scheduled'      => $schedule_display['date'],
 				'schedule_delta' => $schedule_display['delta'],

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -128,13 +128,19 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 	public function get_actions( $request ) {
 		$args     = $this->prepare_actions_query( $request );
 		$actions  = as_get_scheduled_actions( $args );
-		$timezone = new DateTimeZone( get_option( 'timezone_string', 'UTC' ) );
-		$data     = [];
+		try {
+			$timezone = new DateTimeZone( get_option( 'timezone_string' ) );
+		} catch ( Exception $e ) {
+			$timezone = false;
+		}
 
 		foreach ( $actions as $action_id => $action ) {
 			// Display schedule date in more human friendly WP configured time zone.
 			$next = $action->get_schedule()->next();
-			$next->setTimezone( $timezone );
+			if ( $timezone ) {
+				$next->setTimezone( $timezone );
+			}
+
 			$schedule         = new ActionScheduler_SimpleSchedule( $next );
 			$schedule_display = $this->get_schedule_display( $schedule );
 			$parameters       = [];

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -16,6 +16,7 @@ import { onQueryChange, stringifyQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import { statusFilters } from './config';
 const showDatePicker = false;
 
 //@todo: import './style.scss'; if necessary
@@ -40,6 +41,7 @@ class ActionsReport extends Component {
 		this.fetchActionData( {
 			orderby: 'scheduled',
 			order: 'asc',
+			status: 'pending',
 		} );
 	}
 
@@ -116,7 +118,7 @@ class ActionsReport extends Component {
 
 			return [
 				{
-					display: hook,
+					display: this.renderHook( hook ),
 					value: hook,
 				},
 				{
@@ -168,6 +170,26 @@ class ActionsReport extends Component {
 		);
 
 	}
+
+	renderHook( hook ) {
+		if ( hook.length <= 30 ) {
+			return hook;
+		}
+
+		var count = 0;
+		var pieces = hook.split( '_' );
+		for ( var i = 0; i < pieces.length; i++ ) {
+			count += pieces[i].length + 1;
+
+			if ( count >= 30 ) {
+				pieces[i] = ' ' + pieces[i];
+				count = 0;
+			}
+		}
+
+		return pieces.join( '_' );
+	}
+
 	renderPlaceholder() {
 		const headers = this.getHeadersContent();
 		return ( 
@@ -181,24 +203,26 @@ class ActionsReport extends Component {
 	}
 
 	renderTable() {
-		const { query } = this.props;
+		const { path, query } = this.props;
 
 		const rows = this.getRowsContent() || [];
 
 		const headers = this.getHeadersContent();
 
 		return (
-			<TableCard
-				title={ __( 'Scheduled Actions', 'action-scheduler-admin' ) }
-				rows={ rows }
-				totalRows={ rows.length }
-				rowsPerPage={ 100 }
-				headers={ headers }
-				onQueryChange={ onQueryChange }
-				onSort={ onQueryChange }
-				query={ query }
-				summary={ null }
-			/>
+			<Fragment>
+				<TableCard
+					title={ __( 'Scheduled Actions', 'action-scheduler-admin' ) }
+					rows={ rows }
+					totalRows={ rows.length }
+					rowsPerPage={ 100 }
+					headers={ headers }
+					onQueryChange={ onQueryChange }
+					onSort={ onQueryChange }
+					query={ query }
+					summary={ null }
+				/>
+			</Fragment>
 		);
 	}
 
@@ -212,12 +236,16 @@ class ActionsReport extends Component {
 			return (
 				<Fragment>
 					<ReportFilters
-						query={ query }
+						filters={ statusFilters }
 						path={ path }
+						query={ query }
 						showDatePicker={ showDatePicker }
 					/>
 					<EmptyContent
-						title={ __( 'No results could be found.', 'action-scheduler-admin' ) }
+						title={ __( 'No results were found.', 'action-scheduler-admin' ) }
+						message={ __( 'Choose a different Action Status.', 'action-scheduler-admin' ) }
+						actionLabel=""
+						actionURL="#"
 					/>
 				</Fragment>
 			);
@@ -226,8 +254,9 @@ class ActionsReport extends Component {
 		return (
 			<Fragment>
 				<ReportFilters
-					query={ query }
+					filters={ statusFilters }
 					path={ path }
+					query={ query }
 					showDatePicker={ showDatePicker }
 				/>
 				{ ! loading ? this.renderTable() : this.renderPlaceholder() }

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -88,6 +88,7 @@ class ActionsReport extends Component {
 				key: 'scheduled',
 				required: true,
 				defaultSort: true,
+				defaultOrder: 'asc',
 				isSortable: true,
 			},
 			{

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -11,7 +11,7 @@ import { map } from 'lodash';
  * WooCommerce dependencies
  */
 import { Card, EmptyContent, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
-import { onQueryChange, stringifyQuery } from '@woocommerce/navigation';
+import { getQuery, onQueryChange, stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -34,15 +34,10 @@ class ActionsReport extends Component {
 	}
 
 	componentDidMount() {
-		// This should be handled for us automagically, but the nonce wasn't working for me
 		apiFetch.use( apiFetch.createNonceMiddleware( asaSettings.nonce ) );
 		apiFetch.use( apiFetch.createRootURLMiddleware( asaSettings.api_root ) );
 
-		this.fetchActionData( {
-			orderby: 'scheduled',
-			order: 'asc',
-			status: 'pending',
-		} );
+		this.fetchActionData( getQuery() );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -57,7 +52,19 @@ class ActionsReport extends Component {
 	fetchActionData( query ) {
 		const actionsEndpoint = `asa/v1/actions`;
 
-		apiFetch( { path: actionsEndpoint + stringifyQuery( query ) } ).then( actions => {
+		var fullQuery = Object.assign( {
+				orderby: 'scheduled',
+				order: 'asc',
+				status: 'pending',
+			},
+			query
+		);
+
+		if ( fullQuery.status == 'all' ) {
+			fullQuery.status = '';
+		}
+
+		apiFetch( { path: actionsEndpoint + stringifyQuery( fullQuery ) } ).then( actions => {
 			this.setState( {
 				actions: actions,
 				loading: false,

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -10,7 +10,7 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { Card, EmptyContent, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
+import { Card, Date, EmptyContent, ReportFilters, TableCard, TablePlaceholder } from '@woocommerce/components';
 import { getQuery, onQueryChange, stringifyQuery } from '@woocommerce/navigation';
 
 /**
@@ -150,7 +150,7 @@ class ActionsReport extends Component {
 				{
 					display: (
 						<Fragment>
-						{ scheduled }<br />
+						<Date date={ scheduled } screenReaderFormat="F j, Y H:i:s" visibleFormat="Y-m-d H:i:s P" /> <br />
 						{ schedule_delta }
 						</Fragment>
 					),

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -74,6 +74,12 @@ class ActionsReport extends Component {
 				isSortable: true,
 			},
 			{
+				label: __( 'Status', 'action-scheduler-admin' ),
+				key: 'status',
+				required: false,
+				isSortable: false,
+			},
+			{
 				label: __( 'Group', 'action-scheduler-admin' ),
 				key: 'group',
 				required: false,
@@ -109,6 +115,7 @@ class ActionsReport extends Component {
 			const {
 				hook,
 				group,
+				status,
 				parameters,
 				timestamp,
 				scheduled,
@@ -120,6 +127,10 @@ class ActionsReport extends Component {
 				{
 					display: this.renderHook( hook ),
 					value: hook,
+				},
+				{
+					display: status,
+					value: status,
 				},
 				{
 					display: group,
@@ -210,19 +221,17 @@ class ActionsReport extends Component {
 		const headers = this.getHeadersContent();
 
 		return (
-			<Fragment>
-				<TableCard
-					title={ __( 'Scheduled Actions', 'action-scheduler-admin' ) }
-					rows={ rows }
-					totalRows={ rows.length }
-					rowsPerPage={ 100 }
-					headers={ headers }
-					onQueryChange={ onQueryChange }
-					onSort={ onQueryChange }
-					query={ query }
-					summary={ null }
-				/>
-			</Fragment>
+			<TableCard
+				title={ __( 'Scheduled Actions', 'action-scheduler-admin' ) }
+				rows={ rows }
+				totalRows={ rows.length }
+				rowsPerPage={ 100 }
+				headers={ headers }
+				onQueryChange={ onQueryChange }
+				onSort={ onQueryChange }
+				query={ query }
+				summary={ null }
+			/>
 		);
 	}
 

--- a/js/src/config.js
+++ b/js/src/config.js
@@ -1,0 +1,23 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const statusConfig = {
+	label: __( 'Scheduled Action Status', 'action-scheduler-admin' ),
+	staticParams: [ 'order', 'orderby' ],
+	param: 'status',
+	defaultValue: 'pending',
+	showFilters: () => true,
+	filters: [
+		{ label: __( 'All', 'action-scheduler-admin' ), value: 'all' },
+		{ label: __( 'Pending', 'action-scheduler-admin' ), value: 'pending' },
+		{ label: __( 'Completed', 'action-scheduler-admin' ), value: 'complete' },
+		{ label: __( 'In Progress', 'action-scheduler-admin' ), value: 'in-progress' },
+		{ label: __( 'Failed', 'action-scheduler-admin' ), value: 'failed' },
+		{ label: __( 'Canceled', 'action-scheduler-admin' ), value: 'canceled' },
+	]
+}
+
+export const statusFilters = [ statusConfig ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ const externals = {
   '@wordpress/i18n': 'window.wp.i18n',
   '@wordpress/keycodes': { this: [ 'wp', 'keycodes' ] },
   '@woocommerce/components': 'window.wc.components',
+  '@woocommerce/navigation': 'window.wc.navigation',
   tinymce: 'tinymce',
   lodash: 'lodash',
   moment: 'moment',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,19 +17,19 @@ const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-web
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
 const externals = {
-  '@wordpress/api-fetch': 'window.wp.apiFetch',
+  '@wordpress/api-fetch': { this: [ 'wp', 'apiFetch' ] },
   '@wordpress/blocks': { this: [ 'wp', 'blocks' ] },
   '@wordpress/components': { this: [ 'wp', 'components' ] },
   '@wordpress/compose': { this: [ 'wp', 'compose' ] },
   '@wordpress/data': { this: [ 'wp', 'data' ] },
   '@wordpress/editor': { this: [ 'wp', 'editor' ] },
-  '@wordpress/element': 'window.wp.element',
-  '@wordpress/hooks': 'window.wp.hooks',
+  '@wordpress/element': { this: [ 'wp', 'element' ] },
+  '@wordpress/hooks': { this: [ 'wp', 'hooks' ] },
   '@wordpress/html-entities': { this: [ 'wp', 'htmlEntities' ] },
-  '@wordpress/i18n': 'window.wp.i18n',
+  '@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
   '@wordpress/keycodes': { this: [ 'wp', 'keycodes' ] },
-  '@woocommerce/components': 'window.wc.components',
-  '@woocommerce/navigation': 'window.wc.navigation',
+  '@woocommerce/components': { this: [ 'wc', 'components' ] },
+  '@woocommerce/navigation': { this: [ 'wc', 'navigation' ] },
   tinymce: 'tinymce',
   lodash: 'lodash',
   moment: 'moment',
@@ -45,6 +45,8 @@ const webpackConfig = {
   output: {
     filename: './dist/index.js',
     path: __dirname,
+    library: [ 'wc', '[modulename]' ],
+    libraryTarget: 'this',
   },
   externals,
   module: {


### PR DESCRIPTION
Fixes #5

This PR adds
- [x] Table sorting
- [x] Scheduled action status dropdown filter

In the course of doing this PR I found 3 small fixes/changes that needed to be made in other plugins for this to be fully functional:

- ~https://github.com/woocommerce/woocommerce-admin/pull/2150~ Merged

The current implementation of the report dropdown filter has a default of `all` (or unfiltered). This component starts with a list of pending actions. When The above PR is merged `Pending` will be selected in the dropdown on initial load

- ~https://github.com/woocommerce/woocommerce-admin/pull/2139~ Merged

The current implementation of the table card component defaults to assuming the data being initially loaded in descending order on the default sort field. This PR adds a parameter to specify that the inital data is loaded in ascending order on the default sort field.

- https://github.com/Prospress/action-scheduler/pull/299

Using the latest version of Action Scheduler & sorting by group filters out all of the actions that have no group. Once the AS PR is merged then those actions will be at the beginning of the list sorted ascending.