### PR TITLE
Update page registration to work with latest wc-admin.

### DIFF
--- a/classes/ActionScheduler_Admin.php
+++ b/classes/ActionScheduler_Admin.php
@@ -36,8 +36,9 @@ class ActionScheduler_Admin {
 	 */
 	public function add_pages( $report_pages ) {
 		$report_pages[] = array(
+			'id'     => 'woocommerce-analytics-scheduled-actions',
 			'title'  => __( 'Scheduled Actions', 'action-scheduler-admin' ),
-			'parent' => '/analytics/revenue',
+			'parent' => 'woocommerce-analytics',
 			'path'   => '/analytics/scheduled-actions',
 		);
 


### PR DESCRIPTION
The page registration logic in wc-admin was changed a bit in https://github.com/woocommerce/woocommerce-admin/pull/2209 - this small change updates this plugin so the page registration works again.

__To Test__
- Install the latest version of wc-admin or check out master
- Install `master` from `action-scheduler-admin` verify the Analytics > Scheduled Actions menu item is not present
- Checkout this branch, and verify the menu option is shown and functions as expected