### PR TITLE
add checks for broken actions without a schedule

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -15,7 +15,7 @@ import ActionsReport from './as-report';
 /**
  * Use the 'woocommerce_admin_reports_list' filter to add a report page.
  */
-addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', reports => {
+addFilter( 'woocommerce_admin_reports_list', 'scheduled-actions-report-filter', reports => {
   return [
     ...reports,
 	  {
@@ -29,13 +29,9 @@ addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', repo
 /**
  * Use the 'woocommerce_admin_time_excluded_screens' filter to remove date parameters from the query string.
  */
-addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', pages => {
+addFilter( 'woocommerce_admin_time_excluded_screens', 'scheduled-actions-date-filter', pages => {
   return [
     ...pages,
-	{
-		path: '/analytics/scheduled-actions',
-		wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
-		wpClosedMenu: 'toplevel_page_woocommerce',
-	},
+	'scheduled-actions'
   ];
 } );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -6,13 +6,14 @@
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
+
 /**
  * Internal dependencies
  */
 import ActionsReport from './as-report';
 
 /**
- * Use the 'woocommerce-reports-list' filter to add a report page.
+ * Use the 'woocommerce_admin_reports_list' filter to add a report page.
  */
 addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', reports => {
   return [
@@ -22,5 +23,19 @@ addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', repo
 		  title: __( 'Scheduled Actions', 'action-scheduler-admin' ),
 		  component: ActionsReport
 	  },
+  ];
+} );
+
+/**
+ * Use the 'woocommerce_admin_time_excluded_screens' filter to remove date parameters from the query string.
+ */
+addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', pages => {
+  return [
+    ...pages,
+	{
+		path: '/analytics/scheduled-actions',
+		wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
+		wpClosedMenu: 'toplevel_page_woocommerce',
+	},
   ];
 } );


### PR DESCRIPTION
Closes #8 

This PR adds checks to handle trashed actions and actions which are assigned a NullSchedule in https://github.com/Prospress/action-scheduler/pull/292 .
