### PR TITLE
only use the date component when schedule contains a date

### DIFF
--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -196,8 +196,8 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WC_REST_CRUD_Control
 			ksort( $data );
 		}
 
-		$response['actions'] = array_values( $data );
 		// Reset the array keys to prevent downstream key sorting.
+		$response['actions'] = array_values( $data );
 		return rest_ensure_response( $response );
 	}
 

--- a/js/src/as-report.js
+++ b/js/src/as-report.js
@@ -151,7 +151,7 @@ class ActionsReport extends Component {
 				{
 					display: (
 						<Fragment>
-						<Date date={ scheduled } screenReaderFormat="F j, Y H:i:s" visibleFormat="Y-m-d H:i:s P" /> <br />
+						{ scheduled ? <Date date={ scheduled } screenReaderFormat="F j, Y H:i:s" visibleFormat="Y-m-d H:i:s P" /> : scheduled }<br />
 						{ schedule_delta }
 						</Fragment>
 					),

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -15,7 +15,7 @@ import ActionsReport from './as-report';
 /**
  * Use the 'woocommerce_admin_reports_list' filter to add a report page.
  */
-addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', reports => {
+addFilter( 'woocommerce_admin_reports_list', 'scheduled-actions-report-filter', reports => {
   return [
     ...reports,
 	  {
@@ -29,13 +29,9 @@ addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', repo
 /**
  * Use the 'woocommerce_admin_time_excluded_screens' filter to remove date parameters from the query string.
  */
-addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', pages => {
+addFilter( 'woocommerce_admin_time_excluded_screens', 'scheduled-actions-date-filter', pages => {
   return [
     ...pages,
-	{
-		path: '/analytics/scheduled-actions',
-		wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
-		wpClosedMenu: 'toplevel_page_woocommerce',
-	},
+	'scheduled-actions'
   ];
 } );

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -6,13 +6,14 @@
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
+
 /**
  * Internal dependencies
  */
 import ActionsReport from './as-report';
 
 /**
- * Use the 'woocommerce-reports-list' filter to add a report page.
+ * Use the 'woocommerce_admin_reports_list' filter to add a report page.
  */
 addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', reports => {
   return [
@@ -22,5 +23,19 @@ addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', repo
 		  title: __( 'Scheduled Actions', 'action-scheduler-admin' ),
 		  component: ActionsReport
 	  },
+  ];
+} );
+
+/**
+ * Use the 'woocommerce_admin_time_excluded_screens' filter to remove date parameters from the query string.
+ */
+addFilter( 'woocommerce_admin_reports_list', 'analytics/scheduled-actions', pages => {
+  return [
+    ...pages,
+	{
+		path: '/analytics/scheduled-actions',
+		wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
+		wpClosedMenu: 'toplevel_page_woocommerce',
+	},
   ];
 } );


### PR DESCRIPTION
Closes #13 

This PR relies on #12 being merged first. This adds a check that the action schedule field contains a date before rendering a `Date` component.

@psealock Thanks for catching this.