### PR TITLE
explicitly set default timezone to UTC

### DIFF
--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -206,7 +206,8 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WP_REST_Controller {
 		];
 
 		try {
-			$timezone = new DateTimeZone( get_option( 'timezone_string' ) );
+			$timezone_string = get_option( 'timezone_string' );
+			$timezone = new DateTimeZone( empty( $timezone_string ) ? 'UTC' : $timezone_string );
 		} catch ( Exception $e ) {
 			$timezone = false;
 		}

--- a/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
+++ b/classes/ActionScheduler_Admin_Actions_Rest_Controller.php
@@ -206,8 +206,7 @@ class ActionScheduler_Admin_Actions_Rest_Controller extends WP_REST_Controller {
 		];
 
 		try {
-			$timezone_string = get_option( 'timezone_string' );
-			$timezone = new DateTimeZone( empty( $timezone_string ) ? 'UTC' : $timezone_string );
+			$timezone = new DateTimeZone( wp_timezone_string() );
 		} catch ( Exception $e ) {
 			$timezone = false;
 		}


### PR DESCRIPTION
I caught this when I set up a new dev install without the time zone set in the WP settings. The `DateTimeZone` constructor throws an exception when passed an empty string. As a result, the schedule on all actions showed as `async`.


### Testing

- You will need to build with #48 first
- Run `wp option update timezone_string ''`
- Go to WooCommerce -> Scheduled Actions
- The `Schedule` column should display dates for non async actions.